### PR TITLE
ENH: better handing of mafft failure

### DIFF
--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -11,12 +11,23 @@ import subprocess
 from q2_types.feature_data import (DNAFASTAFormat, AlignedDNAFASTAFormat)
 
 
+def run_command(cmd, output_fp, verbose=True):
+    if verbose:
+        print("Running external command line application. This may print "
+              "messages to stdout and/or stderr.")
+        print("The command being run is below. This command cannot "
+              "be manually re-run as it will depend on temporary files that "
+              "no longer exist.")
+        print("\nCommand:", end=' ')
+        print(" ".join(cmd), end='\n\n')
+    with open(output_fp, 'w') as output_f:
+        subprocess.run(cmd, stdout=output_f, check=True)
+
+
 def mafft(sequences: DNAFASTAFormat) -> AlignedDNAFASTAFormat:
     result = AlignedDNAFASTAFormat()
     unaligned_fp = str(sequences)
     aligned_fp = str(result)
-    cmd = ["mafft", "--quiet", "--preservecase", unaligned_fp]
-    # align the sequences and write the output file
-    with open(aligned_fp, 'w') as aligned_f:
-        subprocess.run(cmd, stdout=aligned_f)
+    cmd = ["mafft", "--preservecase", unaligned_fp]
+    run_command(cmd, aligned_fp)
     return result


### PR DESCRIPTION
fixes #4 

Test output is noisy, as this no longer captures stdout/stderr. Open to suggestions on how to handle that (nose doesn't support any capture of stderr).