### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,14 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -c biocore -n test-env python=$PYTHON_VERSION nose flake8 numpy scikit-bio
+  - conda create --yes -c biocore -n test-env python=$PYTHON_VERSION nose numpy scikit-bio
   - source activate test-env
   - conda install --yes -c bioconda mafft
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip
+  - pip install flake8
   - pip install .
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
-  - flake8 q2_alignment setup.py
+  - flake8
+  - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME development team.
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of qiime2 nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2_alignment/__init__.py
+++ b/q2_alignment/__init__.py
@@ -1,14 +1,16 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import pkg_resources
+
 from ._mafft import mafft
 from ._filter import mask
 
-__version__ = '0.0.7.dev0'
+__version__ = pkg_resources.get_distribution('q2-alignment').version
 
 __all__ = ['mafft', 'mask']

--- a/q2_alignment/_filter.py
+++ b/q2_alignment/_filter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -1,13 +1,13 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import Plugin, Float
-from q2_types import FeatureData, Sequence, AlignedSequence
+from qiime2.plugin import Plugin, Float
+from q2_types.feature_data import FeatureData, Sequence, AlignedSequence
 
 import q2_alignment
 

--- a/q2_alignment/test/__init__.py
+++ b/q2_alignment/test/__init__.py
@@ -1,0 +1,7 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------

--- a/q2_alignment/test/test_filter.py
+++ b/q2_alignment/test/test_filter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_alignment/test/test_mafft.py
+++ b/q2_alignment/test/test_mafft.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,9 +10,9 @@ import unittest
 import subprocess
 
 import skbio
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 from q2_types.feature_data import DNAFASTAFormat, AlignedDNAFASTAFormat
-from qiime.util import redirected_stdio
+from qiime2.util import redirected_stdio
 
 from q2_alignment import mafft
 from q2_alignment._mafft import run_command
@@ -50,6 +50,7 @@ class RunCommandTests(TestPluginBase):
         with self.assertRaises(subprocess.CalledProcessError):
             with redirected_stdio(stderr=os.devnull):
                 run_command(cmd, aligned_fp)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,17 +10,17 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-alignment",
-    # TODO stop duplicating version string
-    version="0.0.7.dev0",
+    version="2017.2.0.dev0",
     packages=find_packages(),
-    install_requires=['scikit-bio', 'qiime >= 2.0.6', 'q2-types >= 0.0.6'],
+    install_requires=['qiime2 == 2017.2.*', 'q2-types == 2017.2.*',
+                      'scikit-bio'],
     author="Greg Caporaso",
     author_email="gregcaporaso@gmail.com",
     description="Create and work with alignments in QIIME 2.",
-    license="BSD",
-    url="http://www.qiime.org",
+    license="BSD-3-Clause",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins': ['q2-alignment=q2_alignment.plugin_setup:plugin']
+        'qiime2.plugins': ['q2-alignment=q2_alignment.plugin_setup:plugin']
     },
     package_data={'q2_alignment.test': ['data/*']}
 )


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.