### PR TITLE
MAINT/TST: adds citation and missing test

### DIFF
--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -15,7 +15,11 @@ plugin = Plugin(
     name='alignment',
     version=q2_alignment.__version__,
     website='https://github.com/qiime2/q2-alignment',
-    package='q2_alignment'
+    package='q2_alignment',
+    citation_text=("MAFFT multiple sequence alignment software version 7: "
+                   "improvements in performance and usability. Katoh K, "
+                   "Standley DM. Mol Biol Evol. 2013 Apr;30(4):772-80. "
+                   "doi: 10.1093/molbev/mst010.")
 )
 
 plugin.methods.register_function(

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -51,6 +51,17 @@ class RunCommandTests(TestPluginBase):
             with redirected_stdio(stderr=os.devnull):
                 run_command(cmd, aligned_fp)
 
+    def test_failed_run_not_verbose(self):
+        input_fp = self.get_data_path('unaligned-dna-sequences-1.fasta')
+        input_sequences = DNAFASTAFormat(input_fp, mode='r')
+        output_alignment = AlignedDNAFASTAFormat()
+        unaligned_fp = str(input_sequences)
+        aligned_fp = str(output_alignment)
+        cmd = ["mafft", "--not-a-real-parameter", unaligned_fp]
+        with self.assertRaises(subprocess.CalledProcessError):
+            with redirected_stdio(stderr=os.devnull):
+                run_command(cmd, aligned_fp, verbose=False)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fixes #29

Test coverage should now be 96%. It's not easy to bump to 100%, as the last remaining lines of code support compatibility with both skbio 0.4.2 and 0.5.0. We could hack something to get this to 100%, but that doesn't seem high priority at the moment. 