### PR TITLE
MAINT: Make MAFFT output use PIPE

### DIFF
--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -24,7 +24,9 @@ def run_command(cmd, output_fp, verbose=True):
         print("\nCommand:", end=' ')
         print(" ".join(cmd), end='\n\n')
     with open(output_fp, 'w') as output_f:
-        subprocess.run(cmd, stdout=output_f, check=True)
+        r = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                           check=True)
+        output_f.write(r.stdout.decode('ascii'))
 
 
 def mafft(sequences: DNAFASTAFormat,


### PR DESCRIPTION
Resolves #42 

After switching implicit redirect to instead use `subprocess.PIPE`:

```
>>> biota.util.make_tree(features.DenoisedSequenceVariant, n_threads=5)

Running external command line application. This may print messages to stdout and/or stderr.
The command being run is below. This command cannot be manually re-run as it will depend on temporary files that no longer exist.

Command: mafft --preservecase --inputorder --thread 5 /tmp/qiime2-archive-3xgpoyqm/04012f01-c48d-40cd-87d8-5cd6c52cbbf5/data/dna-sequences.fasta

Running external command line application. This may print messages to stdout and/or stderr.
The command being run is below. This command cannot be manually re-run as it will depend on temporary files that no longer exist.

Command: FastTreeMP -quote -nt /tmp/qiime2-archive-2b86sjlw/f7e3ccb6-68b6-45e7-8c43-40b06ea6dc45/data/aligned-dna-sequences.fasta

<artifact: Phylogeny[Rooted] uuid: e5468e95-d879-40cb-8d28-e00d6464707b>
```
