### PR TITLE
Bump minimum SINA version to 1.3.5

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - qiime2 {{ release }}.*
     - q2-types {{ release }}.*
     - mafft >=7.310
-    - sina >=1.3.4,<=2
+    - sina >=1.3.5,<=2
 
 test:
   imports:


### PR DESCRIPTION
1.3.5 fixes a regression where sequences not matching anything in the reference did not lead to the sequence being dropped but to a crash... :/

See also https://github.com/qiime2/q2-feature-classifier/pull/111 and https://github.com/qiime2/q2-feature-classifier/pull/111