### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_alignment/_filter.py
+++ b/q2_alignment/_filter.py
@@ -60,8 +60,8 @@ def _compute_frequencies(alignment):
                 for c in alignment.iter_positions()]
 
 
-def mask(alignment: skbio.TabularMSA, max_gap_frequency: float=1.0,
-         min_conservation: float=0.40) -> skbio.TabularMSA:
+def mask(alignment: skbio.TabularMSA, max_gap_frequency: float = 1.0,
+         min_conservation: float = 0.40) -> skbio.TabularMSA:
     # check that parameters are in range
     if max_gap_frequency < 0.0 or max_gap_frequency > 1.0:
         raise ValueError('max_gap_frequency out of range [0.0, 1.0]: %f' %

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -28,8 +28,8 @@ def run_command(cmd, output_fp, verbose=True):
 
 
 def mafft(sequences: DNAFASTAFormat,
-          n_threads: int=1,
-          parttree: bool=False) -> AlignedDNAFASTAFormat:
+          n_threads: int = 1,
+          parttree: bool = False) -> AlignedDNAFASTAFormat:
     unaligned_fp = str(sequences)
 
     # Save original sequence IDs since long ids (~250 chars) can be truncated

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Numerous minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.