### PR TITLE
ENH: add support for --addfragments flag

### DIFF
--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -26,7 +26,7 @@ def run_command(cmd, output_fp, verbose=True):
         subprocess.run(cmd, stdout=output_f, check=True)
 
 
-def _mafft(sequences_fp, alignment_fp, n_threads, parttree, fragments):
+def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments):
     # Save original sequence IDs since long ids (~250 chars) can be truncated
     # by mafft. We'll replace the IDs in the aligned sequences file output by
     # mafft with the originals.
@@ -92,7 +92,7 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, fragments):
         cmd += ['--parttree']
 
     if alignment_fp is not None:
-        add_flag = '--addfragments' if fragments else '--add'
+        add_flag = '--addfragments' if addfragments else '--add'
         cmd += [add_flag, sequences_fp, alignment_fp]
     else:
         cmd += [sequences_fp]
@@ -132,7 +132,8 @@ def mafft_add(alignment: AlignedDNAFASTAFormat,
               sequences: DNAFASTAFormat,
               n_threads: int = 1,
               parttree: bool = False,
-              fragments: bool = False) -> AlignedDNAFASTAFormat:
+              addfragments: bool = False) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)
     sequences_fp = str(sequences)
-    return _mafft(sequences_fp, alignment_fp, n_threads, parttree, fragments)
+    return _mafft(
+        sequences_fp, alignment_fp, n_threads, parttree, addfragments)

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -26,7 +26,7 @@ def run_command(cmd, output_fp, verbose=True):
         subprocess.run(cmd, stdout=output_f, check=True)
 
 
-def _mafft(sequences_fp, alignment_fp, n_threads, parttree):
+def _mafft(sequences_fp, alignment_fp, n_threads, parttree, fragments):
     # Save original sequence IDs since long ids (~250 chars) can be truncated
     # by mafft. We'll replace the IDs in the aligned sequences file output by
     # mafft with the originals.
@@ -92,7 +92,8 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree):
         cmd += ['--parttree']
 
     if alignment_fp is not None:
-        cmd += ['--add', sequences_fp, alignment_fp]
+        add_flag = '--addfragments' if fragments else '--add'
+        cmd += [add_flag, sequences_fp, alignment_fp]
     else:
         cmd += [sequences_fp]
 
@@ -124,13 +125,14 @@ def mafft(sequences: DNAFASTAFormat,
           n_threads: int = 1,
           parttree: bool = False) -> AlignedDNAFASTAFormat:
     sequences_fp = str(sequences)
-    return _mafft(sequences_fp, None, n_threads, parttree)
+    return _mafft(sequences_fp, None, n_threads, parttree, False)
 
 
 def mafft_add(alignment: AlignedDNAFASTAFormat,
               sequences: DNAFASTAFormat,
               n_threads: int = 1,
-              parttree: bool = False) -> AlignedDNAFASTAFormat:
+              parttree: bool = False,
+              fragments: bool = False) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)
     sequences_fp = str(sequences)
-    return _mafft(sequences_fp, alignment_fp, n_threads, parttree)
+    return _mafft(sequences_fp, alignment_fp, n_threads, parttree, fragments)

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -59,7 +59,8 @@ plugin.methods.register_function(
                     'aligned are larger than 1000000. Disabled by default',
         'addfragments': 'Optimize for the addition of short sequence '
                         'fragments (for example, primer or amplicon '
-                        'sequences).'},
+                        'sequences). If not set, default sequence addition '
+                        'is used.'},
     output_descriptions={
         'expanded_alignment': 'Alignment containing the provided aligned and '
                               'unaligned sequences.'},

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -46,7 +46,8 @@ plugin.methods.register_function(
     inputs={'alignment': FeatureData[AlignedSequence],
             'sequences': FeatureData[Sequence]},
     parameters={'n_threads': Int % Range(1, None) | Str % Choices(['auto']),
-                'parttree': Bool},
+                'parttree': Bool,
+                'fragments': Bool},
     outputs=[('expanded_alignment', FeatureData[AlignedSequence])],
     input_descriptions={'alignment': 'The alignment to which '
                                      'sequences should be added.',
@@ -55,7 +56,9 @@ plugin.methods.register_function(
         'n_threads': 'The number of threads. (Use `auto` to automatically use '
                      'all available cores)',
         'parttree': 'This flag is required if the number of sequences being '
-                    'aligned are larger than 1000000. Disabled by default'},
+                    'aligned are larger than 1000000. Disabled by default',
+        'fragments': 'This flag indicates that alignment optimized for '
+                     'addition of fragmentary sequences should be used.'},
     output_descriptions={
         'expanded_alignment': 'Alignment containing the provided aligned and '
                               'unaligned sequences.'},

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -47,7 +47,7 @@ plugin.methods.register_function(
             'sequences': FeatureData[Sequence]},
     parameters={'n_threads': Int % Range(1, None) | Str % Choices(['auto']),
                 'parttree': Bool,
-                'fragments': Bool},
+                'addfragments': Bool},
     outputs=[('expanded_alignment', FeatureData[AlignedSequence])],
     input_descriptions={'alignment': 'The alignment to which '
                                      'sequences should be added.',
@@ -57,8 +57,9 @@ plugin.methods.register_function(
                      'all available cores)',
         'parttree': 'This flag is required if the number of sequences being '
                     'aligned are larger than 1000000. Disabled by default',
-        'fragments': 'This flag indicates that alignment optimized for '
-                     'addition of fragmentary sequences should be used.'},
+        'addfragments': 'Optimize for the addition of short sequence '
+                        'fragments (for example, primer or amplicon '
+                        'sequences).'},
     output_descriptions={
         'expanded_alignment': 'Alignment containing the provided aligned and '
                               'unaligned sequences.'},

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -117,7 +117,7 @@ class MafftAddTests(TestPluginBase):
         alignment, sequences, exp = self._prepare_sequence_data()
 
         with redirected_stdio(stderr=os.devnull):
-            result = mafft_add(alignment, sequences, fragments=True)
+            result = mafft_add(alignment, sequences, addfragments=True)
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)
@@ -133,7 +133,7 @@ class MafftAddTests(TestPluginBase):
                     ["mafft", "--preservecase", "--inputorder", "--thread",
                      "1", "--add", ANY, ANY], ANY)
 
-                _ = mafft_add(alignment, sequences, fragments=True)
+                _ = mafft_add(alignment, sequences, addfragments=True)
                 patched_run_cmd.assert_called_with(
                     ["mafft", "--preservecase", "--inputorder", "--thread",
                      "1", "--addfragments", ANY, ANY], ANY)

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 import os
 import unittest
+from unittest.mock import patch, ANY
 import subprocess
 
 import skbio
@@ -19,7 +20,6 @@ from q2_alignment._mafft import run_command
 
 
 class MafftTests(TestPluginBase):
-
     package = 'q2_alignment.tests'
 
     def _prepare_sequence_data(self):
@@ -84,7 +84,6 @@ class MafftTests(TestPluginBase):
 
 
 class MafftAddTests(TestPluginBase):
-
     package = 'q2_alignment.tests'
 
     def _prepare_sequence_data(self):
@@ -113,6 +112,31 @@ class MafftAddTests(TestPluginBase):
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)
+
+    def test_mafft_add_fragments(self):
+        alignment, sequences, exp = self._prepare_sequence_data()
+
+        with redirected_stdio(stderr=os.devnull):
+            result = mafft_add(alignment, sequences, fragments=True)
+        obs = skbio.io.read(str(result), into=skbio.TabularMSA,
+                            constructor=skbio.DNA)
+        self.assertEqual(obs, exp)
+
+    def test_mafft_add_flags(self):
+        alignment, sequences, exp = self._prepare_sequence_data()
+
+        with patch('q2_alignment._mafft.run_command') as patched_run_cmd:
+            with patch('q2_alignment._mafft.skbio.TabularMSA.read',
+                       return_value=exp):
+                _ = mafft_add(alignment, sequences)
+                patched_run_cmd.assert_called_with(
+                    ["mafft", "--preservecase", "--inputorder", "--thread",
+                     "1", "--add", ANY, ANY], ANY)
+
+                _ = mafft_add(alignment, sequences, fragments=True)
+                patched_run_cmd.assert_called_with(
+                    ["mafft", "--preservecase", "--inputorder", "--thread",
+                     "1", "--addfragments", ANY, ANY], ANY)
 
     def test_duplicate_input_ids_in_unaligned(self):
         input_fp = self.get_data_path('unaligned-duplicate-ids.fasta')
@@ -181,7 +205,6 @@ class MafftAddTests(TestPluginBase):
 
 
 class RunCommandTests(TestPluginBase):
-
     package = 'q2_alignment.tests'
 
     def test_failed_run(self):


### PR DESCRIPTION
Adds supports for `--addfragments` flag for addition of fragmentary sequences to existing alignments.

Since it's just a small variant of `mafft_add`, rather than creating a new action I introduced a new parameter in the existing one that will determine whether the `--add` flag (current behaviour) or `--addfragments` one should be used. 
