### PR TITLE
Adds `--keeplength` flag to maff-add action.

### DIFF
--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -26,7 +26,8 @@ def run_command(cmd, output_fp, verbose=True):
         subprocess.run(cmd, stdout=output_f, check=True)
 
 
-def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments):
+def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
+           keeplength):
     # Save original sequence IDs since long ids (~250 chars) can be truncated
     # by mafft. We'll replace the IDs in the aligned sequences file output by
     # mafft with the originals.
@@ -91,9 +92,13 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments):
     if parttree:
         cmd += ['--parttree']
 
+    if keeplength is not None:
+        cmd += ['--keeplength']
+
     if alignment_fp is not None:
         add_flag = '--addfragments' if addfragments else '--add'
         cmd += [add_flag, sequences_fp, alignment_fp]
+
     else:
         cmd += [sequences_fp]
 
@@ -132,8 +137,10 @@ def mafft_add(alignment: AlignedDNAFASTAFormat,
               sequences: DNAFASTAFormat,
               n_threads: int = 1,
               parttree: bool = False,
-              addfragments: bool = False) -> AlignedDNAFASTAFormat:
+              addfragments: bool = False,
+              keeplength: bool = False) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)
     sequences_fp = str(sequences)
     return _mafft(
-        sequences_fp, alignment_fp, n_threads, parttree, addfragments)
+        sequences_fp, alignment_fp, n_threads, parttree, addfragments,
+        keeplength)

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -92,7 +92,7 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
     if parttree:
         cmd += ['--parttree']
 
-    if keeplength is not None:
+    if keeplength:
         cmd += ['--keeplength']
 
     if alignment_fp is not None:
@@ -130,7 +130,7 @@ def mafft(sequences: DNAFASTAFormat,
           n_threads: int = 1,
           parttree: bool = False) -> AlignedDNAFASTAFormat:
     sequences_fp = str(sequences)
-    return _mafft(sequences_fp, None, n_threads, parttree, False)
+    return _mafft(sequences_fp, None, n_threads, parttree, False, False)
 
 
 def mafft_add(alignment: AlignedDNAFASTAFormat,

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -47,7 +47,8 @@ plugin.methods.register_function(
             'sequences': FeatureData[Sequence]},
     parameters={'n_threads': Threads,
                 'parttree': Bool,
-                'addfragments': Bool},
+                'addfragments': Bool,
+                'keeplength': Bool},
     outputs=[('expanded_alignment', FeatureData[AlignedSequence])],
     input_descriptions={'alignment': 'The alignment to which '
                                      'sequences should be added.',
@@ -60,7 +61,12 @@ plugin.methods.register_function(
         'addfragments': 'Optimize for the addition of short sequence '
                         'fragments (for example, primer or amplicon '
                         'sequences). If not set, default sequence addition '
-                        'is used.'},
+                        'is used.',
+        'keeplength': 'If selected, the alignment length will be unchanged. '
+                      'Any added sequence that would otherwise introduce new '
+                      'insertions into the alignment, will have those '
+                      'insertions deleted, to preserve original alignment '
+                      'length.'},
     output_descriptions={
         'expanded_alignment': 'Alignment containing the provided aligned and '
                               'unaligned sequences.'},

--- a/q2_alignment/tests/data/aligned-dna-sequences-2.fasta
+++ b/q2_alignment/tests/data/aligned-dna-sequences-2.fasta
@@ -1,0 +1,5 @@
+>aln-seq-1
+AGGG-GGC
+>aln-seq-2
+AGGGTGGC
+

--- a/q2_alignment/tests/data/unaligned-dna-sequences-2.fasta
+++ b/q2_alignment/tests/data/unaligned-dna-sequences-2.fasta
@@ -1,0 +1,4 @@
+>seq-3
+AGGTTTTGGC
+>seq-4
+AGGTTATGGC

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -165,7 +165,8 @@ class MafftAddTests(TestPluginBase):
         alignment, sequences, exp = self._prepare_sequence_data_2()
 
         with redirected_stdio(stderr=os.devnull):
-            result = mafft_add(alignment, sequences, addfragments=True)
+            result = mafft_add(alignment, sequences, addfragments=True,
+                               keeplength=True)
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)
@@ -174,7 +175,8 @@ class MafftAddTests(TestPluginBase):
         alignment, sequences, exp = self._prepare_sequence_data_3()
 
         with redirected_stdio(stderr=os.devnull):
-            result = mafft_add(alignment, sequences, addfragments=True)
+            result = mafft_add(alignment, sequences, addfragments=True,
+                               keeplength=False)
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -104,6 +104,45 @@ class MafftAddTests(TestPluginBase):
 
         return alignment, sequences, exp
 
+    def _prepare_sequence_data_2(self):
+        # for new alignment using `--keeplength` parameter
+        sequences_fp = self.get_data_path('unaligned-dna-sequences-2.fasta')
+        sequences = DNAFASTAFormat(sequences_fp, mode='r')
+        alignment_fp = self.get_data_path('aligned-dna-sequences-2.fasta')
+        alignment = AlignedDNAFASTAFormat(alignment_fp, mode='r')
+        exp = skbio.TabularMSA(
+            [skbio.DNA('AGGG-GGC',
+                       metadata={'id': 'aln-seq-1', 'description': ''}),
+             skbio.DNA('AGGGTGGC',
+                       metadata={'id': 'aln-seq-2', 'description': ''}),
+             skbio.DNA('AGGTTGGC',
+                       metadata={'id': 'seq-3', 'description': ''}),
+             skbio.DNA('AGGATGGC',
+                       metadata={'id': 'seq-4', 'description': ''})]
+        )
+
+        return alignment, sequences, exp
+
+    def _prepare_sequence_data_3(self):
+        # NOT using `--keeplength` parameter. To compare with
+        # _prepare_sequence_data_2 output
+        sequences_fp = self.get_data_path('unaligned-dna-sequences-2.fasta')
+        sequences = DNAFASTAFormat(sequences_fp, mode='r')
+        alignment_fp = self.get_data_path('aligned-dna-sequences-2.fasta')
+        alignment = AlignedDNAFASTAFormat(alignment_fp, mode='r')
+        exp = skbio.TabularMSA(
+            [skbio.DNA('AGG--G---GGC',
+                       metadata={'id': 'aln-seq-1', 'description': ''}),
+             skbio.DNA('AGG--G--TGGC',
+                       metadata={'id': 'aln-seq-2', 'description': ''}),
+             skbio.DNA('AGG--TTTTGGC',
+                       metadata={'id': 'seq-3', 'description': ''}),
+             skbio.DNA('AGGTTA--TGGC',
+                       metadata={'id': 'seq-4', 'description': ''})]
+        )
+
+        return alignment, sequences, exp
+
     def test_mafft_add(self):
         alignment, sequences, exp = self._prepare_sequence_data()
 
@@ -115,6 +154,24 @@ class MafftAddTests(TestPluginBase):
 
     def test_mafft_add_fragments(self):
         alignment, sequences, exp = self._prepare_sequence_data()
+
+        with redirected_stdio(stderr=os.devnull):
+            result = mafft_add(alignment, sequences, addfragments=True)
+        obs = skbio.io.read(str(result), into=skbio.TabularMSA,
+                            constructor=skbio.DNA)
+        self.assertEqual(obs, exp)
+
+    def test_mafft_add_fragments_keeplength(self):
+        alignment, sequences, exp = self._prepare_sequence_data_2()
+
+        with redirected_stdio(stderr=os.devnull):
+            result = mafft_add(alignment, sequences, addfragments=True)
+        obs = skbio.io.read(str(result), into=skbio.TabularMSA,
+                            constructor=skbio.DNA)
+        self.assertEqual(obs, exp)
+
+    def test_mafft_add_fragments_no_keeplength(self):
+        alignment, sequences, exp = self._prepare_sequence_data_3()
 
         with redirected_stdio(stderr=os.devnull):
             result = mafft_add(alignment, sequences, addfragments=True)


### PR DESCRIPTION
Resolves #83

Allows an option to force the original alignment to keep it's original length while adding new sequences, as outlined [here](https://mafft.cbrc.jp/alignment/software/addsequences.html). 

Users should keep in mind the following from the mafft docs (which is also in the plugin help text):
>If the --keeplength option is given, then the alignment length is unchanged.  Insertions at the new sequences are deleted.