### PR TITLE
ENH: expose mafft `--large` flag to support large alignments

### DIFF
--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -104,7 +104,6 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
                          'together.')
     elif large:
         env = os.environ.copy()
-        env.pop('MAFFT_TMPDIR', 0)
         env.update({'MAFFT_TMPDIR': get_cache().get_tmp_path()})
         cmd += ['--large']
 

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -6,14 +6,16 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import os
 import subprocess
 
 import skbio
 import skbio.io
 from q2_types.feature_data import DNAFASTAFormat, AlignedDNAFASTAFormat
+from qiime2.core.cache import get_cache
 
 
-def run_command(cmd, output_fp, verbose=True):
+def run_command(cmd, output_fp, verbose=True, env=None):
     if verbose:
         print("Running external command line application. This may print "
               "messages to stdout and/or stderr.")
@@ -23,11 +25,11 @@ def run_command(cmd, output_fp, verbose=True):
         print("\nCommand:", end=' ')
         print(" ".join(cmd), end='\n\n')
     with open(output_fp, 'w') as output_f:
-        subprocess.run(cmd, stdout=output_f, check=True)
+        subprocess.run(cmd, stdout=output_f, check=True, env=env)
 
 
 def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
-           keeplength):
+           keeplength, large):
     # Save original sequence IDs since long ids (~250 chars) can be truncated
     # by mafft. We'll replace the IDs in the aligned sequences file output by
     # mafft with the originals.
@@ -77,6 +79,8 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
             "The number of sequences in your feature table is larger than "
             "1 million, please use the parttree parameter")
 
+    env = None
+
     # mafft's signal for utilizing all cores is -1. We want to our users
     # to enter auto for using all cores. This is to prevent any confusion and
     # to keep the UX consisent.
@@ -95,6 +99,15 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
     if keeplength:
         cmd += ['--keeplength']
 
+    if large and addfragments:
+        raise ValueError('--p-addfragments and --p-large cannot be used '
+                         'together.')
+    elif large:
+        env = os.environ.copy()
+        env.pop('MAFFT_TMPDIR', 0)
+        env.update({'MAFFT_TMPDIR': get_cache().get_tmp_path()})
+        cmd += ['--large']
+
     if alignment_fp is not None:
         add_flag = '--addfragments' if addfragments else '--add'
         cmd += [add_flag, sequences_fp, alignment_fp]
@@ -102,7 +115,7 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
     else:
         cmd += [sequences_fp]
 
-    run_command(cmd, result_fp)
+    run_command(cmd, result_fp, env=env)
 
     # Read output alignment into memory, reassign original sequence IDs, and
     # write alignment back to disk.
@@ -128,19 +141,20 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
 
 def mafft(sequences: DNAFASTAFormat,
           n_threads: int = 1,
-          parttree: bool = False) -> AlignedDNAFASTAFormat:
+          parttree: bool = False,
+          large: bool = False) -> AlignedDNAFASTAFormat:
     sequences_fp = str(sequences)
-    return _mafft(sequences_fp, None, n_threads, parttree, False, False)
-
+    return _mafft(sequences_fp, None, n_threads, parttree, False, False, large)
 
 def mafft_add(alignment: AlignedDNAFASTAFormat,
               sequences: DNAFASTAFormat,
               n_threads: int = 1,
               parttree: bool = False,
               addfragments: bool = False,
-              keeplength: bool = False) -> AlignedDNAFASTAFormat:
+              keeplength: bool = False,
+              large: bool = False) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)
     sequences_fp = str(sequences)
     return _mafft(
         sequences_fp, alignment_fp, n_threads, parttree, addfragments,
-        keeplength)
+        keeplength, large)

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -146,6 +146,7 @@ def mafft(sequences: DNAFASTAFormat,
     sequences_fp = str(sequences)
     return _mafft(sequences_fp, None, n_threads, parttree, False, False, large)
 
+
 def mafft_add(alignment: AlignedDNAFASTAFormat,
               sequences: DNAFASTAFormat,
               n_threads: int = 1,

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -12,7 +12,7 @@ import subprocess
 import skbio
 import skbio.io
 from q2_types.feature_data import DNAFASTAFormat, AlignedDNAFASTAFormat
-from qiime2.core.cache import get_cache
+from qiime2 import get_cache
 
 
 def run_command(cmd, output_fp, verbose=True, env=None):

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -27,14 +27,20 @@ plugin.methods.register_function(
     function=q2_alignment.mafft,
     inputs={'sequences': FeatureData[Sequence]},
     parameters={'n_threads': Threads,
-                'parttree': Bool},
+                'parttree': Bool,
+                'large': Bool},
     outputs=[('alignment', FeatureData[AlignedSequence])],
     input_descriptions={'sequences': 'The sequences to be aligned.'},
     parameter_descriptions={
         'n_threads': 'The number of threads. (Use `auto` to automatically use '
                      'all available cores)',
         'parttree': 'This flag is required if the number of sequences being '
-                    'aligned are larger than 1000000. Disabled by default'},
+                    'aligned are larger than 1000000. Disabled by default',
+        'large': 'This flag is required when aligning very large datasets '
+                 'that do not otherwise fit into memory. Temporary data is '
+                 'then stored in files, instead of RAM. The --use-cache '
+                 'flag specifies the storage location of the temporary files '
+                 'created. By default, $TMP/qiime2/ is used.'},
     output_descriptions={'alignment': 'The aligned sequences.'},
     name='De novo multiple sequence alignment with MAFFT',
     description=("Perform de novo multiple sequence alignment using MAFFT."),
@@ -48,7 +54,8 @@ plugin.methods.register_function(
     parameters={'n_threads': Threads,
                 'parttree': Bool,
                 'addfragments': Bool,
-                'keeplength': Bool},
+                'keeplength': Bool,
+                'large': Bool},
     outputs=[('expanded_alignment', FeatureData[AlignedSequence])],
     input_descriptions={'alignment': 'The alignment to which '
                                      'sequences should be added.',
@@ -66,7 +73,12 @@ plugin.methods.register_function(
                       'Any added sequence that would otherwise introduce new '
                       'insertions into the alignment, will have those '
                       'insertions deleted, to preserve original alignment '
-                      'length.'},
+                      'length.',
+        'large': 'This flag is required when aligning very large datasets '
+                 'that do not otherwise fit into memory. Temporary data is '
+                 'then stored in files, instead of RAM. The --use-cache '
+                 'flag specifies the storage location of the temporary files '
+                 'created. By default, $TMP/qiime2/ is used.'},
     output_descriptions={
         'expanded_alignment': 'Alignment containing the provided aligned and '
                               'unaligned sequences.'},

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -82,6 +82,15 @@ class MafftTests(TestPluginBase):
             with redirected_stdio(stderr=os.devnull):
                 mafft(input_sequences)
 
+    def test_mafft_large(self):
+        input_sequences, exp = self._prepare_sequence_data()
+
+        with redirected_stdio(stderr=os.devnull):
+            result = mafft(input_sequences, large=True)
+        obs = skbio.io.read(str(result), into=skbio.TabularMSA,
+                            constructor=skbio.DNA)
+        self.assertEqual(obs, exp)
+
 
 class MafftAddTests(TestPluginBase):
     package = 'q2_alignment.tests'
@@ -181,6 +190,33 @@ class MafftAddTests(TestPluginBase):
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)
 
+    def test_mafft_add_no_keeplength_large(self):
+        alignment, sequences, exp = self._prepare_sequence_data()
+
+        with redirected_stdio(stderr=os.devnull):
+            result = mafft_add(alignment, sequences, keeplength=False,
+                               large=True)
+        obs = skbio.io.read(str(result), into=skbio.TabularMSA,
+                            constructor=skbio.DNA)
+        self.assertEqual(obs, exp)
+
+    def test_mafft_add_keeplength_large(self):
+        alignment, sequences, exp = self._prepare_sequence_data()
+
+        with redirected_stdio(stderr=os.devnull):
+            result = mafft_add(alignment, sequences, keeplength=True,
+                               large=True)
+        obs = skbio.io.read(str(result), into=skbio.TabularMSA,
+                            constructor=skbio.DNA)
+        self.assertEqual(obs, exp)
+
+    def test_mafft_add_fragments_large(self):
+        alignment, sequences, exp = self._prepare_sequence_data()
+
+        with self.assertRaisesRegex(ValueError, '--p-addfragments and.*er.'):
+            with redirected_stdio(stderr=os.devnull):
+                mafft_add(alignment, sequences, addfragments=True, large=True)
+
     def test_mafft_add_flags(self):
         alignment, sequences, exp = self._prepare_sequence_data()
 
@@ -190,12 +226,12 @@ class MafftAddTests(TestPluginBase):
                 _ = mafft_add(alignment, sequences)
                 patched_run_cmd.assert_called_with(
                     ["mafft", "--preservecase", "--inputorder", "--thread",
-                     "1", "--add", ANY, ANY], ANY)
+                     "1", "--add", ANY, ANY], ANY, env=None)
 
                 _ = mafft_add(alignment, sequences, addfragments=True)
                 patched_run_cmd.assert_called_with(
                     ["mafft", "--preservecase", "--inputorder", "--thread",
-                     "1", "--addfragments", ANY, ANY], ANY)
+                     "1", "--addfragments", ANY, ANY], ANY, env=None)
 
     def test_duplicate_input_ids_in_unaligned(self):
         input_fp = self.get_data_path('unaligned-duplicate-ids.fasta')


### PR DESCRIPTION
This pull request addresses issue #69.  It adds supports for `--large` flag, which uses files, instead of RAM, to store temporary data. This is to limit RAM usage when aligning very large files such as may be the case when using long reads, for example. The storage location for the temporary files generated is here specified by the `--use-cache` flag. The `--large` flag has been added to both the mafft and mafft-add commands.

---

An issue arise when trying to use `--addfragments` together with `--large` (output from mafft):

```
Issue when trying to use --addfragments together with --large
--addfragments, --addfull or --addlong is not yet supported for --large or --memsavetree
Use --add newsequences --memsavetree
Or, --addfragments (long, full) newsequences, without --memsavetree
```

Therefore, an error is now raised when using both commands together. This behavior is currently not mentioned explicit in the help menu of either the commands. A question is whether this should be added to one or both of the parameter descriptions.