### PR TITLE
Add additional alignment strategy parameters

### DIFF
--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -15,34 +15,6 @@ from q2_types.feature_data import DNAFASTAFormat, AlignedDNAFASTAFormat
 from qiime2 import get_cache
 
 
-def _validate_alignment_strategy(strategy: str | None) -> str:
-    valid_strategies = [
-        "auto", "fftns", "nofft", "globalpair", "localpair", "genafpair",
-    ]
-    valid_strategies_str = ", ".join(
-        [s for s in valid_strategies])
-
-    if strategy == "auto":
-        return ["--auto"]
-    if strategy == "fftns":
-        return []
-    if strategy == "nofft":
-        return ["--nofft"]
-    if strategy == "localpair":
-        return ["--localpair"]
-    if strategy == "globalpair":
-        return ["--globalpair"]
-    if strategy == "genafpair":
-        return ["--genafpair"]
-    if strategy is None:
-        return []
-    else:
-        raise ValueError(
-            f"Invalid alignment strategy '{strategy}'. "
-            f"Valid values are: {valid_strategies_str}."
-        )
-
-
 def run_command(cmd, output_fp, verbose=True, env=None):
     if verbose:
         print("Running external command line application. This may print "
@@ -136,8 +108,7 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
         cmd += ['--large']
 
     if strategy:
-        strategy_flag = _validate_alignment_strategy(strategy)
-        cmd += strategy_flag
+        cmd += [("--" + strategy)]
 
     # --maxiterate is set to 0 by default, so we only pass this argument onto
     # MAFFT if it deviates from this value.
@@ -184,7 +155,7 @@ def mafft(sequences: DNAFASTAFormat,
           n_threads: int = 1,
           parttree: bool = False,
           large: bool = False,
-          strategy: str = "fftns",
+          strategy: str | None = None,
           maxiterate: int = 0,
           retree: int = 2,) -> AlignedDNAFASTAFormat:
     sequences_fp = str(sequences)
@@ -201,7 +172,7 @@ def mafft_add(alignment: AlignedDNAFASTAFormat,
               addfragments: bool = False,
               keeplength: bool = False,
               large: bool = False,
-              strategy: str = "fftns",
+              strategy: str | None = None,
               maxiterate: int = 0,
               retree: int = 2,) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -29,7 +29,8 @@ def run_command(cmd, output_fp, verbose=True, env=None):
 
 
 def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
-           keeplength, large):
+           keeplength, large, globalpair, localpair, genafpair, maxiterate,
+           retree, nofft, auto):
     # Save original sequence IDs since long ids (~250 chars) can be truncated
     # by mafft. We'll replace the IDs in the aligned sequences file output by
     # mafft with the originals.
@@ -107,6 +108,31 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
         env.update({'MAFFT_TMPDIR': get_cache().get_tmp_path()})
         cmd += ['--large']
 
+    if globalpair:
+        cmd += ['--globalpair']
+
+    if localpair:
+        cmd += ['--localpair']
+
+    if genafpair:
+        cmd += ['--genafpair']
+
+    # --maxiterate is set to 0 by default, so we only pass this argument onto
+    # MAFFT if it deviates from this value.
+    if maxiterate not in (None, 0):
+        cmd += ['--maxiterate', str(maxiterate)]
+
+    # --retree is set to 2 by default, so we only pass this argument onto
+    # MAFFT if it deviates from this value.
+    if retree not in (None, 2):
+        cmd += ['--retree', str(retree)]
+
+    if nofft:
+        cmd += ['--nofft']
+
+    if auto:
+        cmd += ['--auto']
+
     if alignment_fp is not None:
         add_flag = '--addfragments' if addfragments else '--add'
         cmd += [add_flag, sequences_fp, alignment_fp]
@@ -141,9 +167,19 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
 def mafft(sequences: DNAFASTAFormat,
           n_threads: int = 1,
           parttree: bool = False,
-          large: bool = False) -> AlignedDNAFASTAFormat:
+          large: bool = False,
+          globalpair: bool = False,
+          localpair: bool = False,
+          genafpair: bool = False,
+          maxiterate: int = 0,
+          retree: int = 2,
+          nofft: bool = False,
+          auto: bool = False) -> AlignedDNAFASTAFormat:
     sequences_fp = str(sequences)
-    return _mafft(sequences_fp, None, n_threads, parttree, False, False, large)
+    return _mafft(
+        sequences_fp, None, n_threads, parttree, False, False, large,
+        globalpair, localpair, genafpair, maxiterate, retree, nofft, auto
+    )
 
 
 def mafft_add(alignment: AlignedDNAFASTAFormat,
@@ -152,9 +188,18 @@ def mafft_add(alignment: AlignedDNAFASTAFormat,
               parttree: bool = False,
               addfragments: bool = False,
               keeplength: bool = False,
-              large: bool = False) -> AlignedDNAFASTAFormat:
+              large: bool = False,
+              globalpair: bool = False,
+              localpair: bool = False,
+              genafpair: bool = False,
+              maxiterate: int = 0,
+              retree: int = 2,
+              nofft: bool = False,
+              auto: bool = False) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)
     sequences_fp = str(sequences)
     return _mafft(
         sequences_fp, alignment_fp, n_threads, parttree, addfragments,
-        keeplength, large)
+        keeplength, large, globalpair, localpair, genafpair, maxiterate,
+        retree, nofft, auto
+    )

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -15,6 +15,34 @@ from q2_types.feature_data import DNAFASTAFormat, AlignedDNAFASTAFormat
 from qiime2 import get_cache
 
 
+def _validate_alignment_strategy(strategy: str | None) -> str:
+    valid_strategies = [
+        "auto", "fftns", "nofft", "globalpair", "localpair", "genafpair",
+    ]
+    valid_strategies_str = ", ".join(
+        [s for s in valid_strategies])
+
+    if strategy == "auto":
+        return ["--auto"]
+    if strategy == "fftns":
+        return []
+    if strategy == "nofft":
+        return ["--nofft"]
+    if strategy == "localpair":
+        return ["--localpair"]
+    if strategy == "globalpair":
+        return ["--globalpair"]
+    if strategy == "genafpair":
+        return ["--genafpair"]
+    if strategy is None:
+        return []
+    else:
+        raise ValueError(
+            f"Invalid alignment strategy '{strategy}'. "
+            f"Valid values are: {valid_strategies_str}."
+        )
+
+
 def run_command(cmd, output_fp, verbose=True, env=None):
     if verbose:
         print("Running external command line application. This may print "
@@ -29,8 +57,7 @@ def run_command(cmd, output_fp, verbose=True, env=None):
 
 
 def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
-           keeplength, large, globalpair, localpair, genafpair, maxiterate,
-           retree, nofft, auto):
+           keeplength, large, strategy, maxiterate, retree):
     # Save original sequence IDs since long ids (~250 chars) can be truncated
     # by mafft. We'll replace the IDs in the aligned sequences file output by
     # mafft with the originals.
@@ -108,14 +135,9 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
         env.update({'MAFFT_TMPDIR': get_cache().get_tmp_path()})
         cmd += ['--large']
 
-    if globalpair:
-        cmd += ['--globalpair']
-
-    if localpair:
-        cmd += ['--localpair']
-
-    if genafpair:
-        cmd += ['--genafpair']
+    if strategy:
+        strategy_flag = _validate_alignment_strategy(strategy)
+        cmd += strategy_flag
 
     # --maxiterate is set to 0 by default, so we only pass this argument onto
     # MAFFT if it deviates from this value.
@@ -126,12 +148,6 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
     # MAFFT if it deviates from this value.
     if retree not in (None, 2):
         cmd += ['--retree', str(retree)]
-
-    if nofft:
-        cmd += ['--nofft']
-
-    if auto:
-        cmd += ['--auto']
 
     if alignment_fp is not None:
         add_flag = '--addfragments' if addfragments else '--add'
@@ -168,17 +184,13 @@ def mafft(sequences: DNAFASTAFormat,
           n_threads: int = 1,
           parttree: bool = False,
           large: bool = False,
-          globalpair: bool = False,
-          localpair: bool = False,
-          genafpair: bool = False,
+          strategy: str = "fftns",
           maxiterate: int = 0,
-          retree: int = 2,
-          nofft: bool = False,
-          auto: bool = False) -> AlignedDNAFASTAFormat:
+          retree: int = 2,) -> AlignedDNAFASTAFormat:
     sequences_fp = str(sequences)
     return _mafft(
         sequences_fp, None, n_threads, parttree, False, False, large,
-        globalpair, localpair, genafpair, maxiterate, retree, nofft, auto
+        strategy, maxiterate, retree
     )
 
 
@@ -189,17 +201,12 @@ def mafft_add(alignment: AlignedDNAFASTAFormat,
               addfragments: bool = False,
               keeplength: bool = False,
               large: bool = False,
-              globalpair: bool = False,
-              localpair: bool = False,
-              genafpair: bool = False,
+              strategy: str = "fftns",
               maxiterate: int = 0,
-              retree: int = 2,
-              nofft: bool = False,
-              auto: bool = False) -> AlignedDNAFASTAFormat:
+              retree: int = 2,) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)
     sequences_fp = str(sequences)
     return _mafft(
         sequences_fp, alignment_fp, n_threads, parttree, addfragments,
-        keeplength, large, globalpair, localpair, genafpair, maxiterate,
-        retree, nofft, auto
+        keeplength, large, strategy, maxiterate, retree
     )

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -152,8 +152,8 @@ def mafft(sequences: DNAFASTAFormat,
           parttree: bool = False,
           large: bool = False,
           strategy: str | None = None,
-          maxiterate: int = 0,
-          retree: int = 2,) -> AlignedDNAFASTAFormat:
+          maxiterate: int | None = None,
+          retree: int | None = None,) -> AlignedDNAFASTAFormat:
     sequences_fp = str(sequences)
     return _mafft(
         sequences_fp, None, n_threads, parttree, False, False, large,
@@ -169,8 +169,8 @@ def mafft_add(alignment: AlignedDNAFASTAFormat,
               keeplength: bool = False,
               large: bool = False,
               strategy: str | None = None,
-              maxiterate: int = 0,
-              retree: int = 2,) -> AlignedDNAFASTAFormat:
+              maxiterate: int | None = None,
+              retree: int | None = None) -> AlignedDNAFASTAFormat:
     alignment_fp = str(alignment)
     sequences_fp = str(sequences)
     return _mafft(

--- a/q2_alignment/_mafft.py
+++ b/q2_alignment/_mafft.py
@@ -110,14 +110,10 @@ def _mafft(sequences_fp, alignment_fp, n_threads, parttree, addfragments,
     if strategy:
         cmd += [("--" + strategy)]
 
-    # --maxiterate is set to 0 by default, so we only pass this argument onto
-    # MAFFT if it deviates from this value.
-    if maxiterate not in (None, 0):
+    if maxiterate is not None:
         cmd += ['--maxiterate', str(maxiterate)]
 
-    # --retree is set to 2 by default, so we only pass this argument onto
-    # MAFFT if it deviates from this value.
-    if retree not in (None, 2):
+    if retree is not None:
         cmd += ['--retree', str(retree)]
 
     if alignment_fp is not None:

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -19,8 +19,8 @@ mafft_params = {
     "strategy": Str % Choices({
         "auto", "nofft", "globalpair", "localpair", "genafpair",
     }),
-    "maxiterate": Int,
-    "retree": Int,
+    "maxiterate": Int % Range(0, None),
+    "retree": Int % Range(0, None),
 }
 mafft_param_descriptions = {
     "n_threads": "The number of threads. (Use `auto` to automatically use "

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.plugin import (
-    Plugin, Float, Bool, Range, Citations, Threads, Int, Str)
+    Plugin, Float, Bool, Range, Citations, Threads, Int, Str, Choices)
 from q2_types.feature_data import FeatureData, Sequence, AlignedSequence
 
 import q2_alignment
@@ -16,7 +16,9 @@ mafft_params = {
     "n_threads": Threads,
     "parttree": Bool,
     "large": Bool,
-    "strategy": Str,
+    "strategy": Str % Choices({
+        "auto", "nofft", "globalpair", "localpair", "genafpair",
+    }),
     "maxiterate": Int,
     "retree": Int,
 }

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -34,8 +34,8 @@ mafft_param_descriptions = {
              "created. By default, $TMP/qiime2/ is used.",
     "strategy": "Specifies the multiple alignment strategy to use. "
                 "Exactly one strategy may be specified. Valid options "
-                "are: 'auto', 'fftns', 'nofft', 'globalpair', "
-                "'localpair', and 'genafpair'. Default strategy: 'fftns'.",
+                "are: 'auto', 'nofft', 'globalpair', 'localpair', "
+                "and 'genafpair'. Default strategy: FFT-NS.",
     'maxiterate': 'Specifies how many iterative refinement cycles are '
                   'performed after the initial progressive alignment. '
                   'By default, no iterative refinement is performed.',

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -7,10 +7,42 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.plugin import (
-    Plugin, Float, Bool, Range, Citations, Threads, Int)
+    Plugin, Float, Bool, Range, Citations, Threads, Int, Str)
 from q2_types.feature_data import FeatureData, Sequence, AlignedSequence
 
 import q2_alignment
+
+mafft_params = {
+    "n_threads": Threads,
+    "parttree": Bool,
+    "large": Bool,
+    "strategy": Str,
+    "maxiterate": Int,
+    "retree": Int,
+}
+mafft_param_descriptions = {
+    "n_threads": "The number of threads. (Use `auto` to automatically use "
+                 "all available cores)",
+    "parttree": "This flag is required if the number of sequences being "
+                "aligned are larger than 1,000,000. Disabled by default.",
+    "large": "This flag is required when aligning very large datasets "
+             "that do not otherwise fit into memory. Temporary data is "
+             "then stored in files, instead of RAM. The --use-cache "
+             "flag specifies the storage location of the temporary files "
+             "created. By default, $TMP/qiime2/ is used.",
+    "strategy": "Specifies the multiple alignment strategy to use. "
+                "Exactly one strategy may be specified. Valid options "
+                "are: 'auto', 'fftns', 'nofft', 'globalpair', "
+                "'localpair', and 'genafpair'. Default strategy: 'fftns'.",
+    'maxiterate': 'Specifies how many iterative refinement cycles are '
+                  'performed after the initial progressive alignment. '
+                  'By default, no iterative refinement is performed.',
+    'retree': 'Specifies the number of times the guide tree is rebuilt '
+              'during the progressive stage. Typically, tree topology '
+              'stabilizes after 2-3 iterations and higher values rarely '
+              'improves alignment quality enough to justify the extra '
+              'computation.',
+}
 
 citations = Citations.load('citations.bib', package='q2_alignment')
 plugin = Plugin(
@@ -26,55 +58,14 @@ plugin = Plugin(
 plugin.methods.register_function(
     function=q2_alignment.mafft,
     inputs={'sequences': FeatureData[Sequence]},
-    parameters={'n_threads': Threads,
-                'parttree': Bool,
-                'large': Bool,
-                'globalpair': Bool,
-                'localpair': Bool,
-                'genafpair': Bool,
-                'maxiterate': Int,
-                'retree': Int,
-                'nofft': Bool,
-                'auto': Bool},
+    parameters={
+        **mafft_params,
+    },
     outputs=[('alignment', FeatureData[AlignedSequence])],
     input_descriptions={'sequences': 'The sequences to be aligned.'},
     parameter_descriptions={
-        'n_threads': 'The number of threads. (Use `auto` to automatically use '
-                     'all available cores)',
-        'parttree': 'This flag is required if the number of sequences being '
-                    'aligned are larger than 1000000. Disabled by default.',
-        'large': 'This flag is required when aligning very large datasets '
-                 'that do not otherwise fit into memory. Temporary data is '
-                 'then stored in files, instead of RAM. The --use-cache '
-                 'flag specifies the storage location of the temporary files '
-                 'created. By default, $TMP/qiime2/ is used.',
-        'globalpair': 'Compute all pairwise alignments using the '
-                      'Needleman-Wunsch algorithm. Suitable for up to ~200 '
-                      'sequences. A combination with --p-maxiterate 1000 '
-                      'is recommended (G-INS-i).',
-        'localpair': 'Compute all pairwise alignments using the '
-                     'Smith-Waterman algorithm. Suitable for up to ~200 '
-                     'sequences. A combination with --p-maxiterate 1000 '
-                     'is recommended (L-INS-i).',
-        'genafpair': 'Compute all pairwise alignments with a local algorithm '
-                     'with the generalized affine gap cost. Suitable for up '
-                     'to ~200 sequences. A combination with --p-maxiterate '
-                     '1000 is recommended (E-INS-i).',
-        'maxiterate': 'Specifies how many iterative refinement cycles are '
-                      'performed after the initial progressive alignment. '
-                      'By default, no iterative refinement is performed.',
-        'retree': 'Specifies the number of times the guide tree is rebuilt '
-                  'during the progressive stage. Typically, tree topology '
-                  'stabilizes after 2-3 iterations and higher values rarely '
-                  'improves alignment quality enough to justify the extra '
-                  'computation.',
-        'nofft': 'Disables Fast Fourier Transform (FFT) approximation in '
-                 'group-to-group alignment. In general, the FFT algorithm is '
-                 'less efficient for distantly related (i.e., less '
-                 'conserved) sequences.',
-        'auto': 'Automatically select the best alignment strategy '
-                '(from FFT-NS-1, FFT-NS-2, FFT-NS-i, or L-INS-i) based on '
-                'the input\'s data size.'},
+        **mafft_param_descriptions,
+    },
     output_descriptions={'alignment': 'The aligned sequences.'},
     name='De novo multiple sequence alignment with MAFFT',
     description=("Perform de novo multiple sequence alignment using MAFFT."),
@@ -85,27 +76,17 @@ plugin.methods.register_function(
     function=q2_alignment.mafft_add,
     inputs={'alignment': FeatureData[AlignedSequence],
             'sequences': FeatureData[Sequence]},
-    parameters={'n_threads': Threads,
-                'parttree': Bool,
-                'addfragments': Bool,
-                'keeplength': Bool,
-                'large': Bool,
-                'globalpair': Bool,
-                'localpair': Bool,
-                'genafpair': Bool,
-                'maxiterate': Int,
-                'retree': Int,
-                'nofft': Bool,
-                'auto': Bool},
+    parameters={
+        **mafft_params,
+        'addfragments': Bool,
+        'keeplength': Bool,
+    },
     outputs=[('expanded_alignment', FeatureData[AlignedSequence])],
     input_descriptions={'alignment': 'The alignment to which '
                                      'sequences should be added.',
                         'sequences': 'The sequences to be added.'},
     parameter_descriptions={
-        'n_threads': 'The number of threads. (Use `auto` to automatically use '
-                     'all available cores)',
-        'parttree': 'This flag is required if the number of sequences being '
-                    'aligned are larger than 1000000. Disabled by default.',
+        **mafft_param_descriptions,
         'addfragments': 'Optimize for the addition of short sequence '
                         'fragments (for example, primer or amplicon '
                         'sequences). If not set, default sequence addition '
@@ -114,39 +95,7 @@ plugin.methods.register_function(
                       'Any added sequence that would otherwise introduce new '
                       'insertions into the alignment, will have those '
                       'insertions deleted, to preserve original alignment '
-                      'length.',
-        'large': 'This flag is required when aligning very large datasets '
-                 'that do not otherwise fit into memory. Temporary data is '
-                 'then stored in files, instead of RAM. The --use-cache '
-                 'flag specifies the storage location of the temporary files '
-                 'created. By default, $TMP/qiime2/ is used.',
-        'globalpair': 'Compute all pairwise alignments using the '
-                      'Needleman-Wunsch algorithm. Suitable for up to ~200 '
-                      'sequences. A combination with --p-maxiterate 1000 '
-                      'is recommended (G-INS-i).',
-        'localpair': 'Compute all pairwise alignments using the Smith-Waterman'
-                     'algorithm. Suitable for up to ~200 sequences. A '
-                     'combination with --p-maxiterate 1000 is recommended '
-                     '(L-INS-i).',
-        'genafpair': 'Compute all pairwise alignments with a local algorithm '
-                     'with the generalized affine gap cost. Suitable for up '
-                     'to ~200 sequences. A combination with --p-maxiterate '
-                     '1000 is recommended (E-INS-i).',
-        'maxiterate': 'Specifies how many iterative refinement cycles are '
-                      'performed after the initial progressive alignment. '
-                      'By default, no iterative refinement is performed.',
-        'retree': 'Specifies the number of times the guide tree is rebuilt '
-                  'during the progressive stage. Typically, tree topology '
-                  'stabilizes after 2-3 iterations and higher values rarely '
-                  'improves alignment quality enough to justify the extra '
-                  'computation.',
-        'nofft': 'Disables Fast Fourier Transform (FFT) approximation in '
-                 'group-to-group alignment. In general, the FFT algorithm is '
-                 'less efficient for distantly related (i.e., less '
-                 'conserved) sequences.',
-        'auto': 'Automatically select the best alignment strategy '
-                '(from FFT-NS-1, FFT-NS-2, FFT-NS-i, or L-INS-i) based on '
-                'the input\'s data size.'},
+                      'length.'},
     output_descriptions={
         'expanded_alignment': 'Alignment containing the provided aligned and '
                               'unaligned sequences.'},

--- a/q2_alignment/plugin_setup.py
+++ b/q2_alignment/plugin_setup.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.plugin import (
-    Plugin, Float, Bool, Range, Citations, Threads)
+    Plugin, Float, Bool, Range, Citations, Threads, Int)
 from q2_types.feature_data import FeatureData, Sequence, AlignedSequence
 
 import q2_alignment
@@ -28,19 +28,53 @@ plugin.methods.register_function(
     inputs={'sequences': FeatureData[Sequence]},
     parameters={'n_threads': Threads,
                 'parttree': Bool,
-                'large': Bool},
+                'large': Bool,
+                'globalpair': Bool,
+                'localpair': Bool,
+                'genafpair': Bool,
+                'maxiterate': Int,
+                'retree': Int,
+                'nofft': Bool,
+                'auto': Bool},
     outputs=[('alignment', FeatureData[AlignedSequence])],
     input_descriptions={'sequences': 'The sequences to be aligned.'},
     parameter_descriptions={
         'n_threads': 'The number of threads. (Use `auto` to automatically use '
                      'all available cores)',
         'parttree': 'This flag is required if the number of sequences being '
-                    'aligned are larger than 1000000. Disabled by default',
+                    'aligned are larger than 1000000. Disabled by default.',
         'large': 'This flag is required when aligning very large datasets '
                  'that do not otherwise fit into memory. Temporary data is '
                  'then stored in files, instead of RAM. The --use-cache '
                  'flag specifies the storage location of the temporary files '
-                 'created. By default, $TMP/qiime2/ is used.'},
+                 'created. By default, $TMP/qiime2/ is used.',
+        'globalpair': 'Compute all pairwise alignments using the '
+                      'Needleman-Wunsch algorithm. Suitable for up to ~200 '
+                      'sequences. A combination with --p-maxiterate 1000 '
+                      'is recommended (G-INS-i).',
+        'localpair': 'Compute all pairwise alignments using the '
+                     'Smith-Waterman algorithm. Suitable for up to ~200 '
+                     'sequences. A combination with --p-maxiterate 1000 '
+                     'is recommended (L-INS-i).',
+        'genafpair': 'Compute all pairwise alignments with a local algorithm '
+                     'with the generalized affine gap cost. Suitable for up '
+                     'to ~200 sequences. A combination with --p-maxiterate '
+                     '1000 is recommended (E-INS-i).',
+        'maxiterate': 'Specifies how many iterative refinement cycles are '
+                      'performed after the initial progressive alignment. '
+                      'By default, no iterative refinement is performed.',
+        'retree': 'Specifies the number of times the guide tree is rebuilt '
+                  'during the progressive stage. Typically, tree topology '
+                  'stabilizes after 2-3 iterations and higher values rarely '
+                  'improves alignment quality enough to justify the extra '
+                  'computation.',
+        'nofft': 'Disables Fast Fourier Transform (FFT) approximation in '
+                 'group-to-group alignment. In general, the FFT algorithm is '
+                 'less efficient for distantly related (i.e., less '
+                 'conserved) sequences.',
+        'auto': 'Automatically select the best alignment strategy '
+                '(from FFT-NS-1, FFT-NS-2, FFT-NS-i, or L-INS-i) based on '
+                'the input\'s data size.'},
     output_descriptions={'alignment': 'The aligned sequences.'},
     name='De novo multiple sequence alignment with MAFFT',
     description=("Perform de novo multiple sequence alignment using MAFFT."),
@@ -55,7 +89,14 @@ plugin.methods.register_function(
                 'parttree': Bool,
                 'addfragments': Bool,
                 'keeplength': Bool,
-                'large': Bool},
+                'large': Bool,
+                'globalpair': Bool,
+                'localpair': Bool,
+                'genafpair': Bool,
+                'maxiterate': Int,
+                'retree': Int,
+                'nofft': Bool,
+                'auto': Bool},
     outputs=[('expanded_alignment', FeatureData[AlignedSequence])],
     input_descriptions={'alignment': 'The alignment to which '
                                      'sequences should be added.',
@@ -64,7 +105,7 @@ plugin.methods.register_function(
         'n_threads': 'The number of threads. (Use `auto` to automatically use '
                      'all available cores)',
         'parttree': 'This flag is required if the number of sequences being '
-                    'aligned are larger than 1000000. Disabled by default',
+                    'aligned are larger than 1000000. Disabled by default.',
         'addfragments': 'Optimize for the addition of short sequence '
                         'fragments (for example, primer or amplicon '
                         'sequences). If not set, default sequence addition '
@@ -78,7 +119,34 @@ plugin.methods.register_function(
                  'that do not otherwise fit into memory. Temporary data is '
                  'then stored in files, instead of RAM. The --use-cache '
                  'flag specifies the storage location of the temporary files '
-                 'created. By default, $TMP/qiime2/ is used.'},
+                 'created. By default, $TMP/qiime2/ is used.',
+        'globalpair': 'Compute all pairwise alignments using the '
+                      'Needleman-Wunsch algorithm. Suitable for up to ~200 '
+                      'sequences. A combination with --p-maxiterate 1000 '
+                      'is recommended (G-INS-i).',
+        'localpair': 'Compute all pairwise alignments using the Smith-Waterman'
+                     'algorithm. Suitable for up to ~200 sequences. A '
+                     'combination with --p-maxiterate 1000 is recommended '
+                     '(L-INS-i).',
+        'genafpair': 'Compute all pairwise alignments with a local algorithm '
+                     'with the generalized affine gap cost. Suitable for up '
+                     'to ~200 sequences. A combination with --p-maxiterate '
+                     '1000 is recommended (E-INS-i).',
+        'maxiterate': 'Specifies how many iterative refinement cycles are '
+                      'performed after the initial progressive alignment. '
+                      'By default, no iterative refinement is performed.',
+        'retree': 'Specifies the number of times the guide tree is rebuilt '
+                  'during the progressive stage. Typically, tree topology '
+                  'stabilizes after 2-3 iterations and higher values rarely '
+                  'improves alignment quality enough to justify the extra '
+                  'computation.',
+        'nofft': 'Disables Fast Fourier Transform (FFT) approximation in '
+                 'group-to-group alignment. In general, the FFT algorithm is '
+                 'less efficient for distantly related (i.e., less '
+                 'conserved) sequences.',
+        'auto': 'Automatically select the best alignment strategy '
+                '(from FFT-NS-1, FFT-NS-2, FFT-NS-i, or L-INS-i) based on '
+                'the input\'s data size.'},
     output_descriptions={
         'expanded_alignment': 'Alignment containing the provided aligned and '
                               'unaligned sequences.'},

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -16,7 +16,7 @@ from q2_types.feature_data import DNAFASTAFormat, AlignedDNAFASTAFormat
 from qiime2.util import redirected_stdio
 
 from q2_alignment import mafft, mafft_add
-from q2_alignment._mafft import run_command
+from q2_alignment._mafft import run_command, _validate_alignment_strategy
 
 
 class MafftTests(TestPluginBase):
@@ -106,13 +106,31 @@ class MafftTests(TestPluginBase):
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)
 
+    def test_validate_alignment_strategy_valid(self):
+        cases = [
+            ("auto", ["--auto"]),
+            ("fftns", []),
+            ("nofft", ["--nofft"]),
+            ("localpair", ["--localpair"]),
+            ("globalpair", ["--globalpair"]),
+            ("genafpair", ["--genafpair"]),
+            (None, []),
+        ]
+
+        for strategy, expected in cases:
+            assert _validate_alignment_strategy(strategy) == expected
+
+    def test_validate_alignment_strategy_invalid(self):
+        with self.assertRaisesRegex(ValueError, 'Invalid alignment strategy'):
+            _validate_alignment_strategy("invalid")
+
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')
-    def test_mafft_globalpair_flag(self, mock_run_cmd, mock_read):
+    def test_mafft_globalpair_strategy(self, mock_run_cmd, mock_read):
         input_sequences, exp = self._prepare_sequence_data()
         mock_read.return_value = exp
 
-        mafft(input_sequences, globalpair=True)
+        mafft(input_sequences, strategy="globalpair")
 
         mock_run_cmd.assert_called_with(
             ["mafft", "--preservecase", "--inputorder",
@@ -123,11 +141,11 @@ class MafftTests(TestPluginBase):
 
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')
-    def test_mafft_localpair_flag(self, mock_run_cmd, mock_read):
+    def test_mafft_localpair_strategy(self, mock_run_cmd, mock_read):
         input_sequences, exp = self._prepare_sequence_data()
         mock_read.return_value = exp
 
-        mafft(input_sequences, localpair=True)
+        mafft(input_sequences, strategy="localpair")
 
         mock_run_cmd.assert_called_with(
             ["mafft", "--preservecase", "--inputorder",
@@ -138,11 +156,11 @@ class MafftTests(TestPluginBase):
 
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')
-    def test_mafft_genafpair_flag(self, mock_run_cmd, mock_read):
+    def test_mafft_genafpair_strategy(self, mock_run_cmd, mock_read):
         input_sequences, exp = self._prepare_sequence_data()
         mock_read.return_value = exp
 
-        mafft(input_sequences, genafpair=True)
+        mafft(input_sequences, strategy="genafpair")
 
         mock_run_cmd.assert_called_with(
             ["mafft", "--preservecase", "--inputorder",
@@ -211,11 +229,11 @@ class MafftTests(TestPluginBase):
 
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')
-    def test_mafft_nofft_flag(self, mock_run_cmd, mock_read):
+    def test_mafft_nofft_strategy(self, mock_run_cmd, mock_read):
         input_sequences, exp = self._prepare_sequence_data()
         mock_read.return_value = exp
 
-        mafft(input_sequences, nofft=True)
+        mafft(input_sequences, strategy="nofft")
 
         mock_run_cmd.assert_called_with(
             ["mafft", "--preservecase", "--inputorder",
@@ -226,15 +244,30 @@ class MafftTests(TestPluginBase):
 
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')
-    def test_mafft_auto_flag(self, mock_run_cmd, mock_read):
+    def test_mafft_auto_strategy(self, mock_run_cmd, mock_read):
         input_sequences, exp = self._prepare_sequence_data()
         mock_read.return_value = exp
 
-        mafft(input_sequences, auto=True)
+        mafft(input_sequences, strategy="auto")
 
         mock_run_cmd.assert_called_with(
             ["mafft", "--preservecase", "--inputorder",
              "--thread", "1", "--auto", ANY],
+            ANY,
+            env=None
+        )
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_fftns_strategy(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, strategy="fftns")
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", ANY],
             ANY,
             env=None
         )

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -82,6 +82,21 @@ class MafftTests(TestPluginBase):
             with redirected_stdio(stderr=os.devnull):
                 mafft(input_sequences)
 
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_parttree_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, parttree=True)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--parttree", ANY],
+            ANY,
+            env=None
+        )
+
     def test_mafft_large(self):
         input_sequences, exp = self._prepare_sequence_data()
 
@@ -90,6 +105,139 @@ class MafftTests(TestPluginBase):
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_globalpair_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, globalpair=True)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--globalpair", ANY],
+            ANY,
+            env=None
+        )
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_localpair_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, localpair=True)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--localpair", ANY],
+            ANY,
+            env=None
+        )
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_genafpair_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, genafpair=True)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--genafpair", ANY],
+            ANY,
+            env=None
+        )
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_maxiterate_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, maxiterate=1000)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--maxiterate", "1000", ANY],
+            ANY,
+            env=None
+        )
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_maxiterate_not_included_when_default(
+            self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, maxiterate=0)
+
+        call_args, _ = mock_run_cmd.call_args
+        cmd = call_args[0]
+
+        self.assertNotIn("--maxiterate", cmd)
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_retree_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, retree=3)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--retree", "3", ANY],
+            ANY,
+            env=None
+        )
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_retree_not_included_when_default(
+            self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, retree=2)
+
+        call_args, _ = mock_run_cmd.call_args
+        cmd = call_args[0]
+
+        self.assertNotIn("--retree", cmd)
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_nofft_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, nofft=True)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--nofft", ANY],
+            ANY,
+            env=None
+        )
+
+    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
+    @patch('q2_alignment._mafft.run_command')
+    def test_mafft_auto_flag(self, mock_run_cmd, mock_read):
+        input_sequences, exp = self._prepare_sequence_data()
+        mock_read.return_value = exp
+
+        mafft(input_sequences, auto=True)
+
+        mock_run_cmd.assert_called_with(
+            ["mafft", "--preservecase", "--inputorder",
+             "--thread", "1", "--auto", ANY],
+            ANY,
+            env=None
+        )
 
 
 class MafftAddTests(TestPluginBase):

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -16,7 +16,7 @@ from q2_types.feature_data import DNAFASTAFormat, AlignedDNAFASTAFormat
 from qiime2.util import redirected_stdio
 
 from q2_alignment import mafft, mafft_add
-from q2_alignment._mafft import run_command, _validate_alignment_strategy
+from q2_alignment._mafft import run_command
 
 
 class MafftTests(TestPluginBase):
@@ -105,24 +105,6 @@ class MafftTests(TestPluginBase):
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
         self.assertEqual(obs, exp)
-
-    def test_validate_alignment_strategy_valid(self):
-        cases = [
-            ("auto", ["--auto"]),
-            ("fftns", []),
-            ("nofft", ["--nofft"]),
-            ("localpair", ["--localpair"]),
-            ("globalpair", ["--globalpair"]),
-            ("genafpair", ["--genafpair"]),
-            (None, []),
-        ]
-
-        for strategy, expected in cases:
-            assert _validate_alignment_strategy(strategy) == expected
-
-    def test_validate_alignment_strategy_invalid(self):
-        with self.assertRaisesRegex(ValueError, 'Invalid alignment strategy'):
-            _validate_alignment_strategy("invalid")
 
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')
@@ -253,21 +235,6 @@ class MafftTests(TestPluginBase):
         mock_run_cmd.assert_called_with(
             ["mafft", "--preservecase", "--inputorder",
              "--thread", "1", "--auto", ANY],
-            ANY,
-            env=None
-        )
-
-    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
-    @patch('q2_alignment._mafft.run_command')
-    def test_mafft_fftns_strategy(self, mock_run_cmd, mock_read):
-        input_sequences, exp = self._prepare_sequence_data()
-        mock_read.return_value = exp
-
-        mafft(input_sequences, strategy="fftns")
-
-        mock_run_cmd.assert_called_with(
-            ["mafft", "--preservecase", "--inputorder",
-             "--thread", "1", ANY],
             ANY,
             env=None
         )

--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -168,20 +168,6 @@ class MafftTests(TestPluginBase):
 
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')
-    def test_mafft_maxiterate_not_included_when_default(
-            self, mock_run_cmd, mock_read):
-        input_sequences, exp = self._prepare_sequence_data()
-        mock_read.return_value = exp
-
-        mafft(input_sequences, maxiterate=0)
-
-        call_args, _ = mock_run_cmd.call_args
-        cmd = call_args[0]
-
-        self.assertNotIn("--maxiterate", cmd)
-
-    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
-    @patch('q2_alignment._mafft.run_command')
     def test_mafft_retree_flag(self, mock_run_cmd, mock_read):
         input_sequences, exp = self._prepare_sequence_data()
         mock_read.return_value = exp
@@ -194,20 +180,6 @@ class MafftTests(TestPluginBase):
             ANY,
             env=None
         )
-
-    @patch('q2_alignment._mafft.skbio.TabularMSA.read')
-    @patch('q2_alignment._mafft.run_command')
-    def test_mafft_retree_not_included_when_default(
-            self, mock_run_cmd, mock_read):
-        input_sequences, exp = self._prepare_sequence_data()
-        mock_read.return_value = exp
-
-        mafft(input_sequences, retree=2)
-
-        call_args, _ = mock_run_cmd.call_args
-        cmd = call_args[0]
-
-        self.assertNotIn("--retree", cmd)
 
     @patch('q2_alignment._mafft.skbio.TabularMSA.read')
     @patch('q2_alignment._mafft.run_command')


### PR DESCRIPTION
This PR addresses issue #91 by exposing the following set of additional alignment strategy parameters:
- `globalpair`
- `localpair`
- `genafpair`
- `maxiterate`
- `retree`
- `nofft`
- `auto`

These flags allows the user to choose between different alignment algorithms implemented in MAFFT. There is also the `--auto` flag, which automatically decides on the most appropriate algorithm depending on the input data size.

`globalpair`, `localpair`, and `genafpair` are mutually exclusive but the default behavior of MAFFT is to just pick one based on its own internal logic. I've chosen to retain this behavior in the q2-alignment implementation, but a question I have is whether providing more than one of these flags should raise a warning or an error.
