### PR TITLE
BUG: fixes MAFFT failing tests

### DIFF
--- a/q2_alignment/tests/test_mafft.py
+++ b/q2_alignment/tests/test_mafft.py
@@ -27,8 +27,8 @@ class MafftTests(TestPluginBase):
         input_sequences = DNAFASTAFormat(input_fp, mode='r')
         exp = skbio.TabularMSA(
             [skbio.DNA('AGGGGGG', metadata={'id': 'seq1', 'description': ''}),
-             skbio.DNA('-GGGGGG', metadata={'id': 'seq2', 'description': ''})]
-        )
+             skbio.DNA('-GGGGGG', metadata={'id': 'seq2', 'description': ''})],
+            index=['seq1', 'seq2'])
 
         return input_sequences, exp
 
@@ -39,6 +39,7 @@ class MafftTests(TestPluginBase):
             result = mafft(input_sequences)
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
+
         self.assertEqual(obs, exp)
 
     def test_multithreaded_mafft(self):
@@ -89,6 +90,7 @@ class MafftTests(TestPluginBase):
             result = mafft(input_sequences, large=True)
         obs = skbio.io.read(str(result), into=skbio.TabularMSA,
                             constructor=skbio.DNA)
+
         self.assertEqual(obs, exp)
 
 
@@ -108,7 +110,8 @@ class MafftAddTests(TestPluginBase):
              skbio.DNA('AGGGGGG',
                        metadata={'id': 'seq1', 'description': ''}),
              skbio.DNA('-GGGGGG',
-                       metadata={'id': 'seq2', 'description': ''})]
+                       metadata={'id': 'seq2', 'description': ''})],
+            index=['aln-seq-1', 'aln-seq-2', 'seq1', 'seq2']
         )
 
         return alignment, sequences, exp
@@ -127,7 +130,8 @@ class MafftAddTests(TestPluginBase):
              skbio.DNA('AGGTTGGC',
                        metadata={'id': 'seq-3', 'description': ''}),
              skbio.DNA('AGGATGGC',
-                       metadata={'id': 'seq-4', 'description': ''})]
+                       metadata={'id': 'seq-4', 'description': ''})],
+            index=['aln-seq-1', 'aln-seq-2', 'seq-3', 'seq-4']
         )
 
         return alignment, sequences, exp
@@ -147,7 +151,8 @@ class MafftAddTests(TestPluginBase):
              skbio.DNA('AGG--TTTTGGC',
                        metadata={'id': 'seq-3', 'description': ''}),
              skbio.DNA('AGGTTA--TGGC',
-                       metadata={'id': 'seq-4', 'description': ''})]
+                       metadata={'id': 'seq-4', 'description': ''})],
+            index=['aln-seq-1', 'aln-seq-2', 'seq-3', 'seq-4']
         )
 
         return alignment, sequences, exp


### PR DESCRIPTION
This PR addresses failing tests in q2-alignment.

According to this PR: https://github.com/scikit-bio/scikit-bio/pull/2320, Most MSA formats (?) populate the index of the structure using sequence metadata, except FASTQ and FASTA. This was changed in 0.7.1 of Skbio: https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md

Our tests assumed an automatically generated pandas dataframe index like this: pd.RangeIndex(start=0, stop=len(sequences), step=1).

To fix this, I added indexes to our constructors and now all the tests pass locally for me. 